### PR TITLE
Support for Product Name and case sensitive params

### DIFF
--- a/src/components/Checkout.tsx
+++ b/src/components/Checkout.tsx
@@ -132,7 +132,7 @@ const EradpayCheckout: React.FC<EradpayPaymentType> = forwardRef<
     payment_id: payment_id.toString(),
     start_date,
     platform: 'rn',
-    product_name,
+    product_name: encodeURIComponent(product_name || ''),
   };
   const searchParams = new URLSearchParams(
     buildShortQueryParams(queryParams, queryParamsConfigMap)

--- a/src/components/Checkout.tsx
+++ b/src/components/Checkout.tsx
@@ -65,6 +65,7 @@ export type EradpayPaymentType = {
   onPaymentCancelled?: () => void;
   onPaymentCompleted?: () => void;
   product_name?: string;
+  is_case_sensitive?: boolean;
 };
 
 type PressRefHandle = {
@@ -106,6 +107,7 @@ const EradpayCheckout: React.FC<EradpayPaymentType> = forwardRef<
     onPaymentCancelled = () => {},
     onPaymentCompleted = () => {},
     product_name,
+    is_case_sensitive,
   } = props;
 
   const queryParams = {
@@ -137,9 +139,11 @@ const EradpayCheckout: React.FC<EradpayPaymentType> = forwardRef<
   const searchParams = new URLSearchParams(
     buildShortQueryParams(queryParams, queryParamsConfigMap)
   );
-  const checkoutUrl = `${API_BASE_URL}?${searchParams
-    .toString()
-    .toLowerCase()}`;
+  const generateUrl = `${API_BASE_URL}?${searchParams.toString()}`;
+
+  const checkoutUrl = is_case_sensitive
+    ? generateUrl
+    : generateUrl.toLowerCase();
 
   const [modalVisible, setModalVisible] = useState<boolean>(false);
 

--- a/src/components/Checkout.tsx
+++ b/src/components/Checkout.tsx
@@ -64,6 +64,7 @@ export type EradpayPaymentType = {
   buttonTheme?: EradpayThemeEnum;
   onPaymentCancelled?: () => void;
   onPaymentCompleted?: () => void;
+  product_name?: string;
 };
 
 type PressRefHandle = {
@@ -72,7 +73,10 @@ type PressRefHandle = {
 
 const API_BASE_URL = 'https://app.erad.co/eradpay';
 
-const EradpayCheckout: React.FC<EradpayPaymentType> = forwardRef<PressRefHandle,EradpayPaymentType>((props, ref) => {
+const EradpayCheckout: React.FC<EradpayPaymentType> = forwardRef<
+  PressRefHandle,
+  EradpayPaymentType
+>((props, ref) => {
   const {
     amount,
     amount_first_time = 0,
@@ -101,6 +105,7 @@ const EradpayCheckout: React.FC<EradpayPaymentType> = forwardRef<PressRefHandle,
     buttonTheme = EradpayThemeEnum.DEFAULT,
     onPaymentCancelled = () => {},
     onPaymentCompleted = () => {},
+    product_name,
   } = props;
 
   const queryParams = {
@@ -127,6 +132,7 @@ const EradpayCheckout: React.FC<EradpayPaymentType> = forwardRef<PressRefHandle,
     payment_id: payment_id.toString(),
     start_date,
     platform: 'rn',
+    product_name,
   };
   const searchParams = new URLSearchParams(
     buildShortQueryParams(queryParams, queryParamsConfigMap)

--- a/src/components/Checkout.tsx
+++ b/src/components/Checkout.tsx
@@ -136,14 +136,16 @@ const EradpayCheckout: React.FC<EradpayPaymentType> = forwardRef<
     platform: 'rn',
     product_name,
   };
-  const searchParams = new URLSearchParams(
-    buildShortQueryParams(queryParams, queryParamsConfigMap)
-  );
-  const generateUrl = `${API_BASE_URL}?${searchParams.toString()}`;
 
-  const checkoutUrl = is_case_sensitive
-    ? generateUrl
-    : generateUrl.toLowerCase();
+  const generateParams = new URLSearchParams(
+    buildShortQueryParams(queryParams, queryParamsConfigMap)
+  ).toString();
+
+  const searchParams = is_case_sensitive
+    ? generateParams
+    : generateParams.toLowerCase();
+
+  const checkoutUrl = `${API_BASE_URL}?${searchParams}`;
 
   const [modalVisible, setModalVisible] = useState<boolean>(false);
 


### PR DESCRIPTION
- We noticed that the actual payment URL supports giving product name, but the RN Component doesn't so we added the props to it

- Also, since in our use case **we need to send query parameters via webhook URL** and some of those query parameters are case sensitive, additionally we also added a props to control the behavior of **case sensitiveness** when processing the params to be sent to the payment URL

